### PR TITLE
Chore: Cleanup route E2E testing

### DIFF
--- a/kit.js
+++ b/kit.js
@@ -40,7 +40,7 @@ const ingressRoute = app.post('/ingress', async (req, res) => {
     if( message.inReplyTo ){
         routeName = '/reply'
         //We need to look up the message that's being replied to
-        const replyQuery = {selector: {messageId: replyTo}}
+        const replyQuery = {selector: {messageId: message.inReplyTo}}
         replyResult = await app.db.messages.findOne(replyQuery).exec()
     } else {
         //We need to check whether this is the first time we're 
@@ -60,14 +60,14 @@ const ingressRoute = app.post('/ingress', async (req, res) => {
     if(replyResult){
         message.replyingTo = replyResult._data.message
     }
-    const response  = await axios.post(env.APP_TARGET + routeName, resData)
+    const response  = await axios.post(env.APP_TARGET + routeName, message)
 
     //TODO: implement scheduling trigger
     //(new Date).toUTCString() 'o:deliverytime': 'Tue, 16 May 2023 19:11:14 GMT'
     const msg = {
         from: `${env.APP_ADDRESS}@${env.MAIL_DOMAIN}`,
-        to: mail['sender'],
-        subject: mail['subject'],
+        to: message['sender'],
+        subject: message['subject'],
         text: response.data,
     }
     const mgSendRes = await mg.messages.create(env.MAIL_DOMAIN, msg)

--- a/tests.js
+++ b/tests.js
@@ -6,7 +6,8 @@ const env = utils.envConfig()
 const host = `http://localhost:${env.PORT}`
 
 /* For these tests, our goal is to simply utilize all the
- * standard endpoints in a realistic sequence. So, first we
+ * standard endpoints in a realistic sequence. 
+ * Think of them more as simple end to end tests. So, first we
  * hit first-message, reply to first-message, then new message, 
  * followed by a reply, and finally- a scheduled message.
  */
@@ -21,22 +22,33 @@ const mockInitialMail = {
 }
 
 const replyTrigger = triggers.find(t => t.trigger == 'reply')
-let mockInitialReply = mockInitialMail
-mockInitialReply['In-Reply-To'] = '<CAH8yDf6h5h7HQ_vx4e@mail.gmail.com>' 
-mockInitialReply['stripped-text'] = replyTrigger.testInput 
-mockInitialReply['subject'] = 'Re: trying this out' 
+const mockInitialReply = {
+    'Message-Id' : '<AAL8yDf6h5h7HQ_vx4e@mail.gmail.com>',
+    'recipient': `${env.APP_ADDRESS}@${env.MAIL_DOMAIN}`,
+    'sender': 'sam@wpmc.fund',
+    'In-Reply-To' : '<CAH8yDf6h5h7HQ_vx4e@mail.gmail.com>',
+    'stripped-text' : replyTrigger.testInput,
+    'subject' : 'Re: trying this out' 
+}
 
 const newTrigger = triggers.find(t => t.trigger == 'new-message')
-let mockNewMail = mockInitialMail
-mockNewMail['subject'] = 'New thought'
-mockNewMail['stripped-text'] = newTrigger.testInput
+let mockNewMail = {
+    'Message-Id' : '<SDE8yDf6h5h7HQ_vx4e@mail.gmail.com>',
+    'recipient': `${env.APP_ADDRESS}@${env.MAIL_DOMAIN}`,
+    'sender': 'sam@wpmc.fund',
+    'stripped-text' : newTrigger.testInput,
+    'subject' : 'New thought' 
+}
 
 const runTests = async () => {
-    const response = await axios.post(host + '/ingress', mockInitialMail)
-    console.log(response.data)
+    const firstMailResponse = await axios.post(host + '/ingress', mockInitialMail)
+    console.log('First mail response: ', firstMailResponse.data)
 
-    const replyRes = await axios.post(host + '/ingress', mockInitialReply)
-    console.log(replyRes)
+    const replyResponse = await axios.post(host + '/ingress', mockInitialReply)
+    console.log('Reply mail response: ', replyResponse.data)
+
+    const newMailResponse = await axios.post(host + '/ingress', mockNewMail)
+    console.log('New mail response: ', newMailResponse.data)
 }
 
 runTests()

--- a/tests.js
+++ b/tests.js
@@ -1,24 +1,27 @@
 const axios = require('axios')
 const utils = require('./utils.js')  
 
-const host = 'http://localhost:3000'
+const env = utils.envConfig()
+const host = `http://localhost:${env.PORT}`
+
+/* For these tests, our goal is to simply utilize all the
+ * standard endpoints in a realistic sequence. So, first we
+ * hit first-message, reply to first-message, then new message, 
+ * followed by a reply, and finally- a scheduled message.
+ */
 
 const mockInitialMail = {
     'Message-Id': '<CAH8yDf6h5h7HQ_vx4e@mail.gmail.com>',
-    'recipient': 'peace.pal@mail.riseofwizards.com',
+    'recipient': `${env.APP_ADDRESS}@${env.MAIL_DOMAIN}`,
     'sender': 'sam@wpmc.fund',
     'stripped-text': 'Hi- hows this werkk?',
     'subject': 'trying this out'
 }
 
-const mockInitialReply = {
-    'Message-Id': '<OPR8yDf6h5h7HQ_vx4e@mail.gmail.com>',
-    'In-Reply-To': '<CAH8yDf6h5h7HQ_vx4e@mail.gmail.com>',
-    'recipient': 'peace.pal@mail.riseofwizards.com',
-    'sender': 'sam@wpmc.fund',
-    'stripped-text': 'Uncertainty, Sadness',
-    'subject': 'Re: trying this out'
-}
+let mockInitialReply = mockInitialMail
+mockInitialReply['In-Reply-To'] = '<CAH8yDf6h5h7HQ_vx4e@mail.gmail.com>' 
+mockInitialReply['stripped-text'] = 'Uncertainty, Sadness' 
+mockInitialReply['subject'] = 'Re: trying this out' 
 
 const runTests = async () => {
     const response  = await axios.post(host + '/ingress', mockInitialMail)

--- a/tests.js
+++ b/tests.js
@@ -1,5 +1,6 @@
 const axios = require('axios')
 const utils = require('./utils.js')  
+const triggers = require('./triggers.json')
 
 const env = utils.envConfig()
 const host = `http://localhost:${env.PORT}`
@@ -10,24 +11,31 @@ const host = `http://localhost:${env.PORT}`
  * followed by a reply, and finally- a scheduled message.
  */
 
+const firstTrigger = triggers.find(t => t.trigger == 'first-message')
 const mockInitialMail = {
     'Message-Id': '<CAH8yDf6h5h7HQ_vx4e@mail.gmail.com>',
     'recipient': `${env.APP_ADDRESS}@${env.MAIL_DOMAIN}`,
     'sender': 'sam@wpmc.fund',
-    'stripped-text': 'Hi- hows this werkk?',
+    'stripped-text': firstTrigger.testInput,
     'subject': 'trying this out'
 }
 
+const replyTrigger = triggers.find(t => t.trigger == 'reply')
 let mockInitialReply = mockInitialMail
 mockInitialReply['In-Reply-To'] = '<CAH8yDf6h5h7HQ_vx4e@mail.gmail.com>' 
-mockInitialReply['stripped-text'] = 'Uncertainty, Sadness' 
+mockInitialReply['stripped-text'] = replyTrigger.testInput 
 mockInitialReply['subject'] = 'Re: trying this out' 
 
+const newTrigger = triggers.find(t => t.trigger == 'new-message')
+let mockNewMail = mockInitialMail
+mockNewMail['subject'] = 'New thought'
+mockNewMail['stripped-text'] = newTrigger.testInput
+
 const runTests = async () => {
-    const response  = await axios.post(host + '/ingress', mockInitialMail)
+    const response = await axios.post(host + '/ingress', mockInitialMail)
     console.log(response.data)
 
-    const replyRes  = await axios.post(host + '/ingress', mockInitialReply)
+    const replyRes = await axios.post(host + '/ingress', mockInitialReply)
     console.log(replyRes)
 }
 

--- a/triggers.json
+++ b/triggers.json
@@ -1,21 +1,20 @@
 [
     {
-        "action": "field_first_message",
+        "testInput": "Hi- would like to try",
         "description": "initally asks user about what is going to be most valuable to them.",
         "trigger": "first-message"
     },
     {
-        "action": "field_new_message",
+        "testInput": "Im feeling frustrated that people dont understand my art",
         "description": "assesses new message from user",
         "trigger": "new-message"
     },
     {
-        "action": "field_reply",
+        "testInput": "Uncertainty",
         "description": "process a reply to an existing message",
         "trigger": "reply"
     },
     {
-        "action": "scheduled_function",
         "description": "runs process at scheduled time",
         "trigger": "schedule",
         "schedule": "0 8 * * *"

--- a/utils.js
+++ b/utils.js
@@ -22,7 +22,7 @@ const messageSchema = {
     ]
 }
 
-const mailToMessage = (inboundMail) => {
+const mailToMessage = (mail) => {
     const mailMsgMap = {
         'messageId': mail['Message-Id'],
         'sender': mail['sender'],


### PR DESCRIPTION
This PR seeks to hit the basic routes for functionality.
It's a base for future work that will implement a proper testing library as well as cover the `/schedule` route, which was omitted here for simplicity's sake.