### PR TITLE
Feature: Basic schedule test

### DIFF
--- a/kit.js
+++ b/kit.js
@@ -24,16 +24,19 @@ app.use(express.urlencoded({
     extended: true
 }))
 
+//TODO: STOP route/logic
+
 const SCHEDULE_SUBJ_STR = 'Scheduled Send'
-//TODO: determine if body could be useful instead of 'placeholder'
+//TODO: VALIDATE body.to is a email
 const scheduleRoute = app.post('/schedule', async (req, res) => {
     try {
+        const sendTo = req.body.to
         const proposedDateTime = req.body.dateTime
         const newDate = new Date(Date.parse(proposedDateTime))
         const scheduleString = newDate.toUTCString()
         const msg = {subject: SCHEDULE_SUBJ_STR}
         const sentMsg = await msgUtils.mailgunSend(
-            mg, msg, "placeholder", scheduleString
+            mg, msg, sendTo, scheduleString
         )
         //let the ingress POST know that we received OK
         res.status(200).send(sentMsg)
@@ -62,6 +65,7 @@ const ingressRoute = app.post('/ingress', async (req, res) => {
     if(message.sender == message.recipient &&
          message.subject == SCHEDULE_SUBJ_STR) {
         routeName = '/scheduled'
+        message.recipient = message.message
     } else if( message.inReplyTo ){
         routeName = '/reply'
         //We need to look up the message that's being replied to

--- a/tests.js
+++ b/tests.js
@@ -40,7 +40,15 @@ let mockNewMail = {
     'subject' : 'New thought' 
 }
 
-const runTests = async () => {
+const scheduledMail = {
+    'Message-Id': '<SNM8yDf6h5h7HQ_vx4e@mail.gmail.com>',
+    'recipient': `${env.APP_ADDRESS}@${env.MAIL_DOMAIN}`,
+    'sender': `${env.APP_ADDRESS}@${env.MAIL_DOMAIN}`,
+    'stripped-text': 'placeholder',
+    'subject': 'Scheduled Send'
+}
+
+const runCoreTests = async () => {
     const firstMailResponse = await axios.post(host + '/ingress', mockInitialMail)
     console.log('First mail response: ', firstMailResponse.data)
 
@@ -51,4 +59,14 @@ const runTests = async () => {
     console.log('New mail response: ', newMailResponse.data)
 }
 
-runTests()
+const runScheduleTests = async () => {
+    const scheduleResponse = await axios.post(host + '/schedule', {'dateTime': 
+'Sat, 20 May 2023 19:15:00 GMT'})
+    console.log('schedule response: ', scheduleResponse.data)
+
+    const scheduledResponse = await axios.post(host + '/ingress', scheduledMail)
+    console.log('scheduled response: ', scheduledResponse.data)
+}
+
+runCoreTests()
+runScheduleTests()

--- a/tests.js
+++ b/tests.js
@@ -41,10 +41,10 @@ let mockNewMail = {
 }
 
 const scheduledMail = {
-    'Message-Id': '<SNM8yDf6h5h7HQ_vx4e@mail.gmail.com>',
+    'Message-Id': '<ACTWP8yDf6h5h7HQ_vx4e@mail.gmail.com>',
     'recipient': `${env.APP_ADDRESS}@${env.MAIL_DOMAIN}`,
     'sender': `${env.APP_ADDRESS}@${env.MAIL_DOMAIN}`,
-    'stripped-text': 'placeholder',
+    'stripped-text': 'sam@wpmc.fund',
     'subject': 'Scheduled Send'
 }
 
@@ -61,9 +61,9 @@ const runCoreTests = async () => {
 
 const runScheduleTests = async () => {
     const currentDateTime = new Date();
-    //increment DateTime by 5min
+    //increment DateTime by 30min
     const incrementedDT = new Date(currentDateTime.getTime() + 5*60000).toUTCString()
-    const scheduleResponse = await axios.post(host + '/schedule', {'dateTime': incrementedDT})
+    const scheduleResponse = await axios.post(host + '/schedule', {'dateTime': incrementedDT, 'to': 'sam@wpmc.fund'})
     console.log('schedule response: ', scheduleResponse.data)
 
     const scheduledResponse = await axios.post(host + '/ingress', scheduledMail)

--- a/tests.js
+++ b/tests.js
@@ -60,8 +60,10 @@ const runCoreTests = async () => {
 }
 
 const runScheduleTests = async () => {
-    const scheduleResponse = await axios.post(host + '/schedule', {'dateTime': 
-'Sat, 20 May 2023 19:15:00 GMT'})
+    const currentDateTime = new Date();
+    //increment DateTime by 5min
+    const incrementedDT = new Date(currentDateTime.getTime() + 5*60000).toUTCString()
+    const scheduleResponse = await axios.post(host + '/schedule', {'dateTime': incrementedDT})
     console.log('schedule response: ', scheduleResponse.data)
 
     const scheduledResponse = await axios.post(host + '/ingress', scheduledMail)


### PR DESCRIPTION
## Add Schedule test (& companion edit in kit)
* Include test to hit PDK /schedule as well as scheduled trigger through ingress
* Remove hardcoded DateTime in favor of one that increments current DT by 5min
* Update schedule tests to include proper mock mail object
* Rework scheduling logic to accept the target recipient in the body of the /schedule route